### PR TITLE
Firefox support

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -5,13 +5,12 @@
       body {
         font-family: Arial, sans-serif;
         width: 350px; /* or any value up to 800 */
-        height: 400px; /* or any value up to 600 */
+        min-height: 400px; /* or any value up to 600 */
         margin: 0;
         padding: 0;
         display: flex;
         justify-content: center;
         align-items: center;
-        height: 100vh;
         background-color: #03002E;
         color: #f0f0f0;
       }


### PR DESCRIPTION
## Description

You had incorrect (acc. to Firefox) `height` property for `body` tag. This was not allowing the extension to not open the popup.

## Proposed changes

1 I deleted the problematic `height: 100vh` line which was making the panel to not show in Firefox.
2. I replaced `height:400px`  with `min-height:400px` so the panel can expand to full height.

> Note: I do not use Chrome or Edge so I have not been able to test this in that browser. 
> It is merely a cosmetic change and it shouldn't affect the functionality at all in my opinion.

## Screenshot
![ss_jio](https://github.com/user-attachments/assets/d8ccf128-f000-4c7e-8e44-ed930beed177)
